### PR TITLE
chore: update trivy-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
           path: dockle-report.json
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: "${{ env.TEST_TAG }}"
           format: "table"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 TODO.md
+.DS_Store


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- `.gitignore`に`.DS_Store`を追加し、macOSによって生成されるファイルの追跡を防止。
  
- **Chores**
	- GitHub Actions CIワークフローの`trivy-action`のバージョンを`0.24.0`に更新し、脆弱性スキャンの精度を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->